### PR TITLE
fix: import icons from antd lib folder

### DIFF
--- a/build/Icon.mustache
+++ b/build/Icon.mustache
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import Icon, { IconBaseProps } from '@ant-design/icons/es/components/Icon'
+import Icon, { IconBaseProps } from '@ant-design/icons/lib/components/Icon'
 
 /**
  * [{{name}}](https://github.com/Templarian/MaterialDesign-SVG/blob/master/svg/{name}.svg) icon from [Material Design](https://github.com/Templarian/MaterialDesign)


### PR DESCRIPTION
This PR imports icon from the "lib" folder instead of the "es" folder which allows the library to be used with SSR (e.g. NextJS). Otherwise you would see an error like this:
 
````
/Users/.../app/node_modules/@ant-design/icons/es/components/Icon.js:1
import _objectSpread from "@babel/runtime/helpers/esm/objectSpread2";
^^^^^^

SyntaxError: Cannot use import statement outside a module
```